### PR TITLE
[Resolves #1] Forbid improper conversions using `time.Duration()`

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,16 +1,179 @@
 package analyzer
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
+
 	"golang.org/x/tools/go/analysis"
 )
+
+const (
+	ForbidImproperConversions = "forbid-improper-conversions"
+)
+
+var (
+	fForbidImproperConversions bool
+)
+
+func init() {
+	registerFlags()
+}
+
+func registerFlags() {
+	Analyzer.Flags.BoolVar(
+		&fForbidImproperConversions, ForbidImproperConversions, false,
+		"report errors on conversion of integers via `time.Duration()` without multiplying them by proper units like `time.Second`",
+	)
+}
+
+// reset flags to default values; useful for testing
+func resetFlags() {
+	fForbidImproperConversions = false
+}
 
 var Analyzer = &analysis.Analyzer{
 	Name: "durationlint",
 	Doc:  "disallows usage of untyped literals and constants as time.Duration",
 	Run:  run,
+}
+
+// improperDurationContext is a helper to track context of `time.Duration(int)` conversions in a
+// node and in its child nodes; it stores deferred diagnostics that are only reported once it is
+// impossible to multiply all nested `time.Duration(int)` conversions by a time unit.
+//
+// We define a "improper duration" as a node whose type is duration and which has a nested
+// `time.Duration(int)` conversion that hasn't been multiplied by a proper duration such as
+// a duration variable or constant. A "proper duration" is any other node whose type is duration.
+type improperDurationContext struct {
+	node                 ast.Node
+	isMultiplicationExpr bool
+	// Stores whether the current node has type `time.Duration`
+	isDurationType bool
+	// Stores whether the node is itself an "improper" duration, i.e. one of the form
+	// `time.Duration(someIntegerExpression)`.
+	isImproperDurationNode bool
+	// Stores whether the node has a child which is a proper duration
+	hasProperDurationChild bool
+	// Stores whether the node has a child which is an improper duration
+	hasImproperDurationChild bool
+	// Diagnostics which may be reported if no proper child is found or this is not
+	// a multiplication
+	deferredImproperDurationDiagnostics []*analysis.Diagnostic
+}
+
+func (c *improperDurationContext) isProperDuration() bool {
+	if !c.isDurationType {
+		return false
+	}
+	return !c.isImproperDuration()
+}
+
+func (c *improperDurationContext) isImproperDuration() bool {
+	if !c.isDurationType {
+		return false
+	}
+	return c.isImproperDurationNode ||
+		(c.hasImproperDurationChild && !c.isMultiplicationExpr) ||
+		(c.hasImproperDurationChild && !c.hasProperDurationChild)
+}
+
+// stack must be nonempty for any of its methods aside from `PushCurrent` to be called
+type improperDurationContextStack struct {
+	pass     *analysis.Pass
+	sentinel improperDurationContext
+	slice    []improperDurationContext
+}
+
+func (s *improperDurationContextStack) PushCurrent(node ast.Node) {
+	isMultiplicationExpr := false
+	expr, isExpr := node.(ast.Expr)
+	if isExpr {
+		if binaryExpr, isBinaryOp := expr.(*ast.BinaryExpr); isBinaryOp {
+			isMultiplicationExpr = binaryExpr.Op == token.MUL
+		}
+	}
+	position := s.position(node)
+	fmt.Printf("Entering %s\n", position)
+	isDurationExpr := false
+	if isExpr {
+		isDurationExpr = isDurationType(s.pass.TypesInfo.TypeOf(expr))
+	}
+	s.slice = append(s.slice, improperDurationContext{
+		node:                 node,
+		isMultiplicationExpr: isMultiplicationExpr,
+		isDurationType:       isDurationExpr,
+	})
+}
+
+func (s *improperDurationContextStack) position(node ast.Node) token.Position {
+	return s.pass.Fset.Position(node.Pos())
+}
+
+func (s *improperDurationContextStack) PopCurrent() {
+	current := s.current()
+	parent := s.parent()
+	isImproperDuration := current.isImproperDuration()
+	isProperDuration := current.isProperDuration()
+	if isImproperDuration {
+		parent.hasImproperDurationChild = true
+	}
+	if isProperDuration {
+		parent.hasProperDurationChild = true
+	}
+	position := s.position(current.node)
+	fmt.Printf("Exiting %s\n", position)
+	switch {
+	case isProperDuration:
+		// nothing; it's been resolved
+	case !current.isMultiplicationExpr:
+		// immediately report all if any errors; this is not multiplication so it's too late to
+		// fix conversions without a time unit, e.g. `(time.Duration(5) + time.Second)`
+		for _, diagnostic := range current.deferredImproperDurationDiagnostics {
+			s.pass.Report(*diagnostic)
+		}
+	default:
+		// parent might still be able to resolve these improper durations via multiplication with
+		// a proper duration, e.g. `(5 * time.Duration(someInt)) * time.Second`
+		parent.deferredImproperDurationDiagnostics = append(
+			parent.deferredImproperDurationDiagnostics,
+			current.deferredImproperDurationDiagnostics...,
+		)
+	}
+	// free up memory now that diagnostics are deferred or reported
+	current.deferredImproperDurationDiagnostics = nil
+	s.slice = s.slice[:len(s.slice)-1]
+}
+
+func (s *improperDurationContextStack) current() *improperDurationContext {
+	return &s.slice[len(s.slice)-1]
+}
+
+func (s *improperDurationContextStack) parent() *improperDurationContext {
+	if len(s.slice) == 1 {
+		return &s.sentinel
+	}
+	return &s.slice[len(s.slice)-2]
+}
+
+func (s *improperDurationContextStack) ReportImproperDurationNode(diagnostic *analysis.Diagnostic) {
+	s.current().isImproperDurationNode = true
+	// parent might be able to resolve this improper duration via multiplication with a
+	// proper duration, e.g. parent could be `time.Duration(5) * time.Second` when child is
+	// `time.Duration(5)`
+	parent := s.parent()
+	parent.deferredImproperDurationDiagnostics = append(
+		parent.deferredImproperDurationDiagnostics,
+		diagnostic,
+	)
+}
+
+func (s *improperDurationContextStack) Finish() {
+	for _, diagnostic := range s.sentinel.deferredImproperDurationDiagnostics {
+		s.ReportImproperDurationNode(diagnostic)
+	}
+	s.sentinel.deferredImproperDurationDiagnostics = nil
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -19,7 +182,17 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		// other assignment and call expressions, we want to always return true
 		// to continue descending the tree
 
+		stack := improperDurationContextStack{
+			pass: pass,
+		}
+		defer stack.Finish()
 		ast.Inspect(file, func(node ast.Node) bool {
+			isExitingNodeTraversal := node == nil
+			if !isExitingNodeTraversal {
+				stack.PushCurrent(node)
+			} else {
+				defer stack.PopCurrent()
+			}
 			switch v := node.(type) {
 			case *ast.KeyValueExpr:
 				diag := checkAssignment(pass, v.Key, v.Value)
@@ -50,17 +223,25 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				return true
 
 			case *ast.CallExpr:
-				if shouldExcludeCall(v) {
-					return false
-				}
-				for _, arg := range v.Args {
-					diag := checkArgument(pass, arg)
-					if diag != nil {
-						pass.Report(*diag)
+				isConversion := isDurationConversion(v)
+				if isConversion {
+					if !fForbidImproperConversions {
+						return false
 					}
+					diag := checkDurationConversionArgument(pass, v.Args[0])
+					if diag != nil {
+						stack.ReportImproperDurationNode(diag)
+					}
+					return true
+				} else {
+					for _, arg := range v.Args {
+						diag := checkArgument(pass, arg)
+						if diag != nil {
+							pass.Report(*diag)
+						}
+					}
+					return true
 				}
-				return true
-
 			default:
 				return true
 			}
@@ -70,10 +251,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func checkArgument(pass *analysis.Pass, v ast.Expr) *analysis.Diagnostic {
-	if pass.TypesInfo.TypeOf(v).String() != "time.Duration" {
+	if !isDurationType(pass.TypesInfo.TypeOf(v)) {
 		return nil
 	}
-	if !usesUntypedConstants(pass.TypesInfo, v) {
+	if !usesIntOrUntypedConstants(pass.TypesInfo, v) {
 		return nil
 	}
 	return &analysis.Diagnostic{
@@ -82,30 +263,45 @@ func checkArgument(pass *analysis.Pass, v ast.Expr) *analysis.Diagnostic {
 	}
 }
 
+func checkDurationConversionArgument(pass *analysis.Pass, arg ast.Expr) *analysis.Diagnostic {
+	argType := pass.TypesInfo.TypeOf(arg)
+	implicitInt := usesIntOrUntypedConstants(pass.TypesInfo, arg)
+	explicitInt := isIntegerType(argType)
+	if !implicitInt && !explicitInt {
+		return nil
+	}
+	return &analysis.Diagnostic{
+		Pos:     arg.Pos(),
+		Message: "converting integer via time.Duration() without multiplication by proper duration",
+	}
+}
+
 func checkAssignment(pass *analysis.Pass, l ast.Expr, r ast.Expr) *analysis.Diagnostic {
 	lType := pass.TypesInfo.TypeOf(l)
 	if lType == nil || lType.String() != "time.Duration" {
 		return nil
 	}
-	if !usesUntypedConstants(pass.TypesInfo, r) {
+	if !usesIntOrUntypedConstants(pass.TypesInfo, r) {
 		return nil
 	}
 	return &analysis.Diagnostic{Pos: r.Pos(), Message: "untyped constant in time.Duration assignment"}
 }
 
-func usesUntypedConstants(ti *types.Info, e ast.Expr) bool {
+func usesIntOrUntypedConstants(ti *types.Info, e ast.Expr) bool {
 	switch v := e.(type) {
 	case *ast.BasicLit: // ex: 1
 		return v.Value != "0"
 	case *ast.BinaryExpr:
 		switch v.Op {
-		case token.ADD: // ex: 1 + time.Seconds
-			return usesUntypedConstants(ti, v.X) || usesUntypedConstants(ti, v.Y)
+		case token.ADD, token.SUB: // ex: 1 + time.Seconds
+			return usesIntOrUntypedConstants(ti, v.X) || usesIntOrUntypedConstants(ti, v.Y)
 		case token.MUL: // ex: 1 * time.Seconds
-			return usesUntypedConstants(ti, v.X) && usesUntypedConstants(ti, v.Y)
+			return usesIntOrUntypedConstants(ti, v.X) && usesIntOrUntypedConstants(ti, v.Y)
 		}
 	case *ast.Ident: // ex: someIdentifier
-		return hasUntypedConstDeclaration(ti, v)
+		return hasIntOrUntypedConstDeclaration(ti, v)
+	case *ast.ParenExpr:
+		return usesIntOrUntypedConstants(ti, v.X)
 	}
 	return false
 }
@@ -113,7 +309,7 @@ func usesUntypedConstants(ti *types.Info, e ast.Expr) bool {
 // we only care about untyped `const Name = 123` declarations
 // `var Name = 123`, and `a := 123` declarations are already type-checked
 // by the compiler
-func hasUntypedConstDeclaration(ti *types.Info, identifier *ast.Ident) bool {
+func hasIntOrUntypedConstDeclaration(ti *types.Info, identifier *ast.Ident) bool {
 	decl := identifier.Obj.Decl
 
 	// TODO: we could ignore `var` statements altogether
@@ -124,8 +320,8 @@ func hasUntypedConstDeclaration(ti *types.Info, identifier *ast.Ident) bool {
 	}
 
 	// typed const or var declaration,
-	// we can ignore it as it is already type-checked
-	if vSpec.Type != nil {
+	// we can ignore it if it isn't an integer
+	if vSpec.Type != nil && !isIntegerType(ti.TypeOf(vSpec.Type)) {
 		return false
 	}
 
@@ -152,14 +348,38 @@ func hasUntypedConstDeclaration(ti *types.Info, identifier *ast.Ident) bool {
 	return false
 }
 
-// shouldExcludeCall prevents `time.Duration(10)` from being reported
-func shouldExcludeCall(v *ast.CallExpr) bool {
+// isDurationConversion recognizes `time.Duration(10)` in order either to not report it at all or
+// to report it differently than other errors, depending on the value of `fForbidExplicitCast`
+func isDurationConversion(v *ast.CallExpr) bool {
 	se, ok := v.Fun.(*ast.SelectorExpr)
 	if !ok {
+		return false
+	}
+	if len(v.Args) != 1 {
+		// Duration conversion should take exactly one argument; if not, it's some other call
 		return false
 	}
 
 	// NOTE: we don't check the package name in the selector expression, as it
 	// could have been aliased to something else
 	return se.Sel.Name == "Duration"
+}
+
+// checks if a type is an integer (e.g. int64, int, int32, uint32)
+func isIntegerType(typ types.Type) bool {
+	switch typ := typ.(type) {
+	case *types.Basic:
+		if typ.Info()&types.IsInteger != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// checks if a type is `time.Duration`
+func isDurationType(typ types.Type) bool {
+	if typ == nil {
+		return false
+	}
+	return typ.String() == "time.Duration"
 }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -94,8 +94,6 @@ func (s *improperDurationContextStack) PushCurrent(node ast.Node) {
 			isMultiplicationExpr = binaryExpr.Op == token.MUL
 		}
 	}
-	position := s.position(node)
-	fmt.Printf("Entering %s\n", position)
 	isDurationExpr := false
 	if isExpr {
 		isDurationExpr = isDurationType(s.pass.TypesInfo.TypeOf(expr))
@@ -105,10 +103,6 @@ func (s *improperDurationContextStack) PushCurrent(node ast.Node) {
 		isMultiplicationExpr: isMultiplicationExpr,
 		isDurationType:       isDurationExpr,
 	})
-}
-
-func (s *improperDurationContextStack) position(node ast.Node) token.Position {
-	return s.pass.Fset.Position(node.Pos())
 }
 
 func (s *improperDurationContextStack) PopCurrent() {
@@ -122,8 +116,6 @@ func (s *improperDurationContextStack) PopCurrent() {
 	if isProperDuration {
 		parent.hasProperDurationChild = true
 	}
-	position := s.position(current.node)
-	fmt.Printf("Exiting %s\n", position)
 	switch {
 	case isProperDuration:
 		// nothing; it's been resolved

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,13 +1,15 @@
 package analyzer
 
 import (
-	"golang.org/x/tools/go/analysis/analysistest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-func TestAll(t *testing.T) {
+func TestDefaultFlags(t *testing.T) {
+	resetFlags()
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Failed to get wd: %s", err)
@@ -15,4 +17,17 @@ func TestAll(t *testing.T) {
 
 	testdata := filepath.Join(filepath.Dir(filepath.Dir(wd)), "testdata")
 	analysistest.Run(t, testdata, Analyzer, "p1")
+}
+
+func TestForbidImproperDurationConversions(t *testing.T) {
+	resetFlags()
+	fForbidExplicitConversion = true
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %s", err)
+	}
+
+	testdata := filepath.Join(filepath.Dir(filepath.Dir(wd)), "testdata")
+	analysistest.Run(t, testdata, Analyzer, "forbid_improper_conversion")
+
 }

--- a/testdata/src/forbid_improper_conversion/test.go
+++ b/testdata/src/forbid_improper_conversion/test.go
@@ -1,0 +1,69 @@
+package forbid_improper_conversion
+
+import (
+	"time"
+)
+
+const untypedConst = 30
+const implicitTimeConst = time.Second
+const typedConst time.Duration = time.Second
+const ignored2, untypedConst2 = 10, 10
+
+const derivedConst = typedConst
+const derivedUntypedConst = untypedConst
+const intTypedConst int = 10
+
+type CustomDuration int
+
+const customDurationConst CustomDuration = 10
+
+type TestStruct struct {
+	DurationField1 time.Duration
+	DurationField2 time.Duration
+	DurationField3 time.Duration
+}
+
+func useTestStruct(TestStruct) {
+}
+
+func returnsInteger() uint8 {
+	return 5
+}
+
+func returnsDuration(integer int) time.Duration {
+	return time.Duration(integer) * time.Second
+}
+
+func acceptsDuration(time.Duration) {
+}
+
+func TestDurationConversionSuccess() {
+	var predefindInt int = 5
+	_ = time.Duration(customDurationConst)
+	_ = time.Duration(20 * (time.Second + time.Microsecond))
+	_ = time.Duration(5) * time.Second
+	_ = time.Duration(predefindInt) * time.Second
+	_ = time.Duration(untypedConst) * time.Nanosecond
+	_ = 50 * time.Duration(untypedConst) * time.Nanosecond * time.Duration(predefindInt)
+	_ = time.Duration(typedConst)
+	_ = time.Duration(implicitTimeConst)
+	_ = time.Duration(returnsDuration(5))
+}
+
+func TestDurationConversionErrors() {
+	var predefindInt int = 5
+	_ = time.Duration(10)                  // want `converting integer via time.Duration.. without multiplication by proper duration`
+	_ = time.Duration(untypedConst)        // want `converting integer via time.Duration.. without multiplication by proper duration`
+	_ = time.Duration(derivedUntypedConst) // want `converting integer via time.Duration.. without multiplication by proper duration`
+	_ = time.Duration(intTypedConst)       // want `converting integer via time.Duration.. without multiplication by proper duration`
+
+	// more complex nesting with conversion over call expression
+	useTestStruct(TestStruct{
+		DurationField1: time.Duration(returnsInteger()), // want `converting integer via time.Duration.. without multiplication by proper duration`
+		DurationField2: time.Duration(predefindInt),     // want `converting integer via time.Duration.. without multiplication by proper duration`
+		DurationField3: time.Duration(10),               // want `converting integer via time.Duration.. without multiplication by proper duration`
+	})
+	acceptsDuration(time.Duration(returnsInteger())) // want `converting integer via time.Duration.. without multiplication by proper duration`
+	acceptsDuration(time.Duration(predefindInt))     // want `converting integer via time.Duration.. without multiplication by proper duration`
+	acceptsDuration(time.Duration(10))               // want `converting integer via time.Duration.. without multiplication by proper duration`
+}


### PR DESCRIPTION
This PR introduces a new `forbid-improper-conversions` flag which, when enabled, will cause the analyzer to raise
errors on invocations of `time.Duration()` on non-duration integer types _unless_ these invocations are multiplied
by "proper" durations like `time.Millisecond` subsequently.

This helps capture a class of bugs caused by a lack of awareness that `time.Duration()` converts its integer arguments
to nanoseconds. It would be nice to forbid conversions via `time.Duration()` entirely, but it is necessary
because existing integer variables such as "timeout in milliseconds" cannot be multiplied by the time units due to
having a defined and mismatching type compared to `time.Duration`.

Resolves #1 